### PR TITLE
Add CI testing shell structure.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,47 @@
+---
+# Github actions workflow file
+name: magic_carpet_linting
+
+on:  # yamllint disable rule:truthy
+    push:
+        branches:
+            - main
+            - feature/*
+        paths-ignore:
+            - 'README.md'
+            - 'TODO.md'
+    pull_request:
+        branches:
+            - main
+        paths-ignore:
+            - 'README.md'
+            - 'TODO.md'
+
+jobs:
+    build:
+        name: Lint and test
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: [3.7, 3.8, 3.9]
+        steps:
+            - uses: actions/checkout@v2
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v2
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install dependencies
+              run: |
+                python -m pip install --upgrade pip
+                pip install -r requirements-lint.txt
+                pip freeze install
+            - name: Execute black formatting check
+              run: make black
+            - name: Execute pylama check
+              run: make pylama
+            - name: Execute yamllint check
+              run: make yamllint
+            - name: Execute bandit check
+              run: make bandit
+            - name: Execute pytest (Github actions version)
+              run: make pytest-gh-actions

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ __pycache__/
 
 # VSCode
 .vscode
+
+# Skip virtualenv folders
+.venv/
+venv/

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,15 @@
+---
+
+# YAMLlint Configuration file
+# Ignore the virtual environment folder
+ignore: |
+   venv/
+   .yamllint.yaml
+
+extends: default
+
+rules:
+    # 120 chars should be enough, but don't fail if a line is longer
+    line-length:
+        max: 120
+        level: warning

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help:
+	@grep '^[a-zA-Z]' $(MAKEFILE_LIST) | \
+	sort | \
+	awk -F ':.*?## ' 'NF==2 {printf "\033[35m  %-25s\033[0m %s\n", $$1, $$2}'
+
+all: lint-all tests ## Perform all linting checks, security checks and tests
+lint-all:	black pylama yamllint bandit ## Perform all linting and security checks (black, pylama, yamllint and bandit).
+
+black: ## Format code using black
+	@echo "--- Performing black reformatting ---"
+	black . --check
+
+pylama:	## Perform python linting using pylama
+	@echo "--- Performing pylama linting ---"
+	pylama .
+
+yamllint:	## Perform YAML linting using yamllint
+	@echo "--- Performing yamllint linting ---"
+	yamllint .
+
+bandit:	## Perform python code security checks using bandit
+	@echo "--- Performing bandit code security scanning ---"
+	bandit motherstarter/ -v --exclude ./venv --recursive --format json --verbose -s B101
+
+
+

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ yamllint:	## Perform YAML linting using yamllint
 
 bandit:	## Perform python code security checks using bandit
 	@echo "--- Performing bandit code security scanning ---"
-	bandit motherstarter/ -v --exclude ./venv --recursive --format json --verbose -s B101
+	bandit . -v --exclude ./venv --recursive --format json --verbose -s B101
 
 
 

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,5 @@
+# Requirements file for linting checks
+bandit
+black
+pylama
+yamllint

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+# Pylama setup configuration file
+[pylama]
+linters = pep8,mccabe,pyflakes
+skip = venv/*,.nox/*
+
+[pylama:pep8]
+max_line_length = 100
+# ignore E231 missing whitespace after ',' [pep8]
+# ignore W503 line break before binary operator
+ignore = E231, W503
+
+[pylama:pycodestyle]
+max_line_length = 100


### PR DESCRIPTION
Hi @automateyournetwork,

This PR contains a shell structure which I think you should attempt to adopt to your project. I'll explain the files

## requirements-lint.txt

Contains the list of python modules needed for performing linting checks. These are:
 - black
 - bandit
 - pylama
 - yamllint

## .yamllint.yaml - yamllint configuration file

You can adjust this file to your requirements. I've setup a basic, boiler plate one which I use.

## setup.cfg - pylama configuration file

You can adjust this file to your requirements. I've setup a basic, boiler plate one which I use.

## Makefile - Boiler plate Makefile

The Makefile comes with a built-in menu and is also used in the Github Actions file.
Makefiles are great for CI tools, you probably would have seen them in the pyATS work.

## .github/workflows/main.yaml - Github Actions File

This YAML file leverages the `requirements-lint.txt` file and the `Makefile` to perform the automated CI tests.
At this point, unless people pass these checks, you can also them to go resolve the issue(s).

## Sample outputs

Below are the current issues with the code in this repo, which fail the respective linting checks:

### black checks

```python
(venv) ➜  magic_carpet git:(feature/gh-actions-uplift) ✗ black *.py --check
would reformat /mnt/c/Users/dfjt/Documents/networking/projects/magic_carpet/magic_carpet/IOS_XE_magic_carpet_job.py
would reformat /mnt/c/Users/dfjt/Documents/networking/projects/magic_carpet/magic_carpet/JUNOS_magic_carpet_job.py
would reformat /mnt/c/Users/dfjt/Documents/networking/projects/magic_carpet/magic_carpet/JUNOS_magic_carpet.py
would reformat /mnt/c/Users/dfjt/Documents/networking/projects/magic_carpet/magic_carpet/IOS_XE_magic_carpet.py
Oh no! 💥 💔 💥
4 files would be reformatted.
```

### pylama checks

```python
(venv) ➜  magic_carpet git:(feature/gh-actions-uplift) ✗ make pylama
--- Performing pylama linting ---
pylama .
IOS_XE_magic_carpet.py:10:1: W0611 'os' imported but unused [pyflakes]
IOS_XE_magic_carpet.py:11:1: W0611 'sys' imported but unused [pyflakes]
IOS_XE_magic_carpet.py:13:1: W0611 'time' imported but unused [pyflakes]
IOS_XE_magic_carpet.py:15:1: W0611 'shutil' imported but unused [pyflakes]
IOS_XE_magic_carpet.py:21:1: W0611 'pyats.topology' imported but unused [pyflakes]
IOS_XE_magic_carpet.py:22:1: W0611 'pyats.log.utils.banner' imported but unused [pyflakes]
IOS_XE_magic_carpet.py:58:1: C901 'Collect_Information.parse' is too complex (69) [mccabe]
IOS_XE_magic_carpet_job.py:11:1: E302 expected 2 blank lines, found 1 [pep8]
IOS_XE_magic_carpet_job.py:29:62: W292 no newline at end of file [pep8]
JUNOS_magic_carpet.py:28:12: W291 trailing whitespace [pep8]
JUNOS_magic_carpet.py:33:1: E302 expected 2 blank lines, found 1 [pep8]
JUNOS_magic_carpet.py:39:101: E501 line too long (575 > 100 characters) [pep8]
JUNOS_magic_carpet.py:39:215: W605 invalid escape sequence '\)' [pep8]
JUNOS_magic_carpet.py:39:270: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:39:281: W605 invalid escape sequence '\,' [pep8]
JUNOS_magic_carpet.py:39:287: W605 invalid escape sequence '\|' [pep8]
JUNOS_magic_carpet.py:39:296: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:39:306: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:39:308: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:39:322: W605 invalid escape sequence '\>' [pep8]
JUNOS_magic_carpet.py:39:337: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:39:388: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:39:403: W605 invalid escape sequence '\-' [pep8]
JUNOS_magic_carpet.py:39:426: W605 invalid escape sequence '\_' [pep8]
JUNOS_magic_carpet.py:39:485: W605 invalid escape sequence '\_' [pep8]
JUNOS_magic_carpet.py:54:101: E501 line too long (723 > 100 characters) [pep8]
JUNOS_magic_carpet.py:54:95: W605 invalid escape sequence '\/' [pep8]
JUNOS_magic_carpet.py:54:112: W605 invalid escape sequence '\/' [pep8]
JUNOS_magic_carpet.py:54:150: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:54:168: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:54:186: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:54:224: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:54:230: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:54:254: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:54:260: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:54:266: W605 invalid escape sequence '\|' [pep8]
JUNOS_magic_carpet.py:54:306: W605 invalid escape sequence '\-' [pep8]
JUNOS_magic_carpet.py:54:426: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:66:101: E501 line too long (107 > 100 characters) [pep8]
JUNOS_magic_carpet.py:68:101: E501 line too long (134 > 100 characters) [pep8]
JUNOS_magic_carpet.py:71:101: E501 line too long (134 > 100 characters) [pep8]
JUNOS_magic_carpet.py:75:101: E501 line too long (177 > 100 characters) [pep8]
JUNOS_magic_carpet.py:77:101: E501 line too long (136 > 100 characters) [pep8]
JUNOS_magic_carpet.py:81:101: E501 line too long (924 > 100 characters) [pep8]
JUNOS_magic_carpet.py:81:462: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet.py:81:546: W605 invalid escape sequence '\ ' [pep8]
JUNOS_magic_carpet_job.py:11:1: E302 expected 2 blank lines, found 1 [pep8]
make: *** [Makefile:19: pylama] Error 1
```

### bandit checks

```python
(venv) ➜  magic_carpet git:(feature/gh-actions-uplift) ✗ bandit . -v --exclude ./venv --recursive --format json --verbose -s B101
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: B101
{
  "errors": [],
  "generated_at": "2021-03-23T10:08:10Z",
  "metrics": {
    "./IOS_XE_magic_carpet.py": {
      "CONFIDENCE.HIGH": 1.0,
      "CONFIDENCE.LOW": 0.0,
      "CONFIDENCE.MEDIUM": 0.0,
      "CONFIDENCE.UNDEFINED": 0.0,
      "SEVERITY.HIGH": 1.0,
      "SEVERITY.LOW": 0.0,
      "SEVERITY.MEDIUM": 0.0,
      "SEVERITY.UNDEFINED": 0.0,
      "loc": 283,
      "nosec": 0
    },
    "./IOS_XE_magic_carpet_job.py": {
      "CONFIDENCE.HIGH": 0.0,
      "CONFIDENCE.LOW": 0.0,
      "CONFIDENCE.MEDIUM": 0.0,
      "CONFIDENCE.UNDEFINED": 0.0,
      "SEVERITY.HIGH": 0.0,
      "SEVERITY.LOW": 0.0,
      "SEVERITY.MEDIUM": 0.0,
      "SEVERITY.UNDEFINED": 0.0,
      "loc": 14,
      "nosec": 0
    },
    "./JUNOS_magic_carpet.py": {
      "CONFIDENCE.HIGH": 1.0,
      "CONFIDENCE.LOW": 0.0,
      "CONFIDENCE.MEDIUM": 0.0,
      "CONFIDENCE.UNDEFINED": 0.0,
      "SEVERITY.HIGH": 1.0,
      "SEVERITY.LOW": 0.0,
      "SEVERITY.MEDIUM": 0.0,
      "SEVERITY.UNDEFINED": 0.0,
      "loc": 43,
      "nosec": 0
    },
    "./JUNOS_magic_carpet_job.py": {
      "CONFIDENCE.HIGH": 0.0,
      "CONFIDENCE.LOW": 0.0,
      "CONFIDENCE.MEDIUM": 0.0,
      "CONFIDENCE.UNDEFINED": 0.0,
      "SEVERITY.HIGH": 0.0,
      "SEVERITY.LOW": 0.0,
      "SEVERITY.MEDIUM": 0.0,
      "SEVERITY.UNDEFINED": 0.0,
      "loc": 14,
      "nosec": 0
    },
    "_totals": {
      "CONFIDENCE.HIGH": 2.0,
      "CONFIDENCE.LOW": 0.0,
      "CONFIDENCE.MEDIUM": 0.0,
      "CONFIDENCE.UNDEFINED": 0.0,
      "SEVERITY.HIGH": 2.0,
      "SEVERITY.LOW": 0.0,
      "SEVERITY.MEDIUM": 0.0,
      "SEVERITY.UNDEFINED": 0.0,
      "loc": 354,
      "nosec": 0
    }
  },
  "results": [
    {
      "code": "41 template_dir = 'templates/cisco/ios_xe'\n42 env = Environment(loader=FileSystemLoader(template_dir))\n43 \n",
      "filename": "./IOS_XE_magic_carpet.py",
      "issue_confidence": "HIGH",
      "issue_severity": "HIGH",
      "issue_text": "By default, jinja2 sets autoescape to False. Consider using autoescape=True or use the select_autoescape function to mitigate XSS vulnerabilities.",
      "line_number": 42,
      "line_range": [
        42
      ],
      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html",
      "test_id": "B701",
      "test_name": "jinja2_autoescape_false"
    },
    {
      "code": "19 template_dir = \"templates/juniper\"\n20 env = Environment(loader=FileSystemLoader(template_dir))\n21 \n",
      "filename": "./JUNOS_magic_carpet.py",
      "issue_confidence": "HIGH",
      "issue_severity": "HIGH",
      "issue_text": "By default, jinja2 sets autoescape to False. Consider using autoescape=True or use the select_autoescape function to mitigate XSS vulnerabilities.",
      "line_number": 20,
      "line_range": [
        20
      ],
      "more_info": "https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html",
      "test_id": "B701",
      "test_name": "jinja2_autoescape_false"
    }
  ]
}%
```

### yamllint checks

```python
(venv) ➜  magic_carpet git:(feature/gh-actions-uplift) ✗ yamllint .
./testbed/testbed_ios_xe.yaml
  1:1       warning  missing document start "---"  (document-start)
  3:7       error    wrong indentation: expected 8 but found 6  (indentation)
  8:9       error    wrong indentation: expected 10 but found 8  (indentation)
  9:11      error    wrong indentation: expected 12 but found 10  (indentation)
  9:23      error    too many spaces inside braces  (braces)
  9:37      error    too many spaces inside braces  (braces)
  10:23     error    too many spaces inside braces  (braces)
  10:37     error    too many spaces inside braces  (braces)
  11:19     error    trailing spaces  (trailing-spaces)
  12:9      error    wrong indentation: expected 10 but found 8  (indentation)
  13:11     error    wrong indentation: expected 12 but found 10  (indentation)
  14:17     error    too many spaces inside braces  (braces)
  14:32     error    too many spaces inside braces  (braces)
  16:13     error    wrong indentation: expected 14 but found 12  (indentation)
  16:36     error    trailing spaces  (trailing-spaces)
  18:7      error    wrong indentation: expected 8 but found 6  (indentation)
  23:9      error    wrong indentation: expected 10 but found 8  (indentation)
  24:11     error    wrong indentation: expected 12 but found 10  (indentation)
  24:23     error    too many spaces inside braces  (braces)
  24:37     error    too many spaces inside braces  (braces)
  25:23     error    too many spaces inside braces  (braces)
  25:37     error    too many spaces inside braces  (braces)
  26:19     error    trailing spaces  (trailing-spaces)
  27:9      error    wrong indentation: expected 10 but found 8  (indentation)
  28:11     error    wrong indentation: expected 12 but found 10  (indentation)
  29:17     error    too many spaces inside braces  (braces)
  29:32     error    too many spaces inside braces  (braces)
  31:13     error    wrong indentation: expected 14 but found 12  (indentation)
  33:7      error    wrong indentation: expected 8 but found 6  (indentation)
  38:9      error    wrong indentation: expected 10 but found 8  (indentation)
  39:11     error    wrong indentation: expected 12 but found 10  (indentation)
  39:23     error    too many spaces inside braces  (braces)
  39:37     error    too many spaces inside braces  (braces)
  40:23     error    too many spaces inside braces  (braces)
  40:37     error    too many spaces inside braces  (braces)
  41:19     error    trailing spaces  (trailing-spaces)
  42:9      error    wrong indentation: expected 10 but found 8  (indentation)
  43:11     error    wrong indentation: expected 12 but found 10  (indentation)
  44:17     error    too many spaces inside braces  (braces)
  44:32     error    too many spaces inside braces  (braces)
  46:13     error    wrong indentation: expected 14 but found 12  (indentation)
  46:36     error    trailing spaces  (trailing-spaces)

./testbed/testbed_juniper.yaml
  1:1       warning  missing document start "---"  (document-start)
  3:7       error    wrong indentation: expected 8 but found 6  (indentation)
  6:9       error    wrong indentation: expected 10 but found 8  (indentation)
  7:11      error    wrong indentation: expected 12 but found 10  (indentation)
  7:23      error    too many spaces inside braces  (braces)
  7:37      error    too many spaces inside braces  (braces)
  8:23      error    too many spaces inside braces  (braces)
  8:37      error    too many spaces inside braces  (braces)
  10:9      error    wrong indentation: expected 10 but found 8  (indentation)
  11:11     error    wrong indentation: expected 12 but found 10  (indentation)
  12:17     error    too many spaces inside braces  (braces)
  12:32     error    too many spaces inside braces  (braces)
  14:13     error    wrong indentation: expected 14 but found 12  (indentation)

(venv) ➜  magic_carpet git:(feature/gh-actions-uplift) ✗
```

As you can see, there are a few defects which should be worked through in terms of failing linting checks.