### PR TITLE
Clean code

### DIFF
--- a/DevNet_Sandbox_CSR_magic_carpet.py
+++ b/DevNet_Sandbox_CSR_magic_carpet.py
@@ -147,15 +147,18 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/%s_learned_acl.json" % device.alias, "w") as fid:
                         json.dump(self.learned_acl, fid, indent=4, sort_keys=True)
+                        fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/%s_learned_acl.yaml" % device.alias, "w") as yml:
-                        yaml.dump(self.learned_acl, yml, allow_unicode=True)                
+                        yaml.dump(self.learned_acl, yml, allow_unicode=True)
+                        yml.close()           
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_acl_template.render(to_parse_access_list=self.learned_acl['acls'],filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/%s_learned_acl.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type) 
+                            fh.close()
                     
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/%s_learned_acl.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/%s_learned_acl.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/%s_learned_acl_mind_map.html" % (device.alias,device.alias))
@@ -164,10 +167,12 @@ class Collect_Information(aetest.Testcase):
                     parsed_output_netjson_html = learned_acl_netjson_html_template.render(device_alias = device.alias)
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/%s_learned_acl_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)               
+                        fh.write(parsed_output_netjson_json)
+                        fh.close()        
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/%s_learned_acl_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
+                        fh.close()
 
                     # ----------------
                     # Store ACLs in Device Table in Database
@@ -186,21 +191,25 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.json" % device.alias, "w") as fid:
                         json.dump(self.learned_arp, fid, indent=4, sort_keys=True)
+                        fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.yaml" % device.alias, "w") as yml:
                         yaml.dump(self.learned_arp, yml, allow_unicode=True)   
+                        yml.close()
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_arp_template.render(to_parse_arp=self.learned_arp['interfaces'],filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type) 
+                            fh.close()
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_arp_statistics_template.render(to_parse_arp=self.learned_arp['statistics'],filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_statistics.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type) 
+                            fh.close()
 
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_mind_map.html" % (device.alias,device.alias))
@@ -212,19 +221,23 @@ class Collect_Information(aetest.Testcase):
                     parsed_output_netjson_html = learned_arp_netjson_html_template.render(device_alias = device.alias)
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)               
+                        fh.write(parsed_output_netjson_json)      
+                        fh.close()         
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
+                        fh.close()
 
                     parsed_output_netjson_json = learned_arp_statistics_netjson_json_template.render(to_parse_arp=self.learned_arp['statistics'],device_alias = device.alias)
                     parsed_output_netjson_html = learned_arp_statistics_netjson_html_template.render(device_alias = device.alias)
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_statistics_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)               
+                        fh.write(parsed_output_netjson_json)     
+                        fh.close()          
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_statistics_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
+                        fh.close()
 
                     # ----------------
                     # Store ARP in Device Table in Database
@@ -243,15 +256,18 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x.json" % device.alias, "w") as fid:
                         json.dump(self.learned_dot1x, fid, indent=4, sort_keys=True)
+                        fh.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x.yaml" % device.alias, "w") as yml:
-                        yaml.dump(self.learned_dot1x, yml, allow_unicode=True)                
+                        yaml.dump(self.learned_dot1x, yml, allow_unicode=True)   
+                        yml.close()             
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_dot1x_template.render(to_parse_dot1x=self.learned_dot1x,filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type) 
+                            fh.close()
                     
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x_mind_map.html" % (device.alias,device.alias))
@@ -260,16 +276,19 @@ class Collect_Information(aetest.Testcase):
                     parsed_output_netjson_html = learned_dot1x_netjson_html_template.render(device_alias = device.alias)
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)               
+                        fh.write(parsed_output_netjson_json) 
+                        fh.close()              
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
+                        fh.close()
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_dot1x_sessions_template.render(to_parse_dot1x=self.learned_dot1x,filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x_sessions.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type) 
+                            fh.close()
                     
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x_sessions.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x_sessions.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x_sessions_mind_map.html" % (device.alias,device.alias))
@@ -279,9 +298,11 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x_sessions_netgraph.json" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_json)               
+                        fh.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x_sessions_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
+                        fh.close()
 
                     # ----------------
                     # Store dot1X in Device Table in Database
@@ -299,15 +320,18 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.json" % device.alias, "w") as fid:
                         json.dump(self.learned_interface, fid, indent=4, sort_keys=True)
+                        fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.yaml" % device.alias, "w") as yml:
                         yaml.dump(self.learned_interface, yml, allow_unicode=True)   
+                        yml.close()
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_interface_template.render(to_parse_interface=self.learned_interface,filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type) 
+                            fh.close()
                     
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface_mind_map.html" % (device.alias,device.alias))
@@ -316,19 +340,23 @@ class Collect_Information(aetest.Testcase):
                     parsed_output_netjson_html = learned_interface_netjson_html_template.render(device_alias = device.alias)
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)               
+                        fh.write(parsed_output_netjson_json)   
+                        fh.close()            
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
+                        fh.close()
 
                     parsed_output_netjson_json = learned_interface_enable_netjson_json_template.render(to_parse_interface=self.learned_interface,device_alias = device.alias)
                     parsed_output_netjson_html = learned_interface_enable_netjson_html_template.render(device_alias = device.alias)
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface_enabled_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)               
+                        fh.write(parsed_output_netjson_json)
+                        fh.close()               
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface_enabled_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
+                        fh.close()
 
                     # ----------------
                     # Store Interface in Device Table in Database
@@ -344,15 +372,18 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Routing/%s_learned_routing.json" % device.alias, "w") as fid:
                         json.dump(self.learned_routing, fid, indent=4, sort_keys=True)
+                        fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Routing/%s_learned_routing.yaml" % device.alias, "w") as yml:
-                        yaml.dump(self.learned_routing, yml, allow_unicode=True)                
+                        yaml.dump(self.learned_routing, yml, allow_unicode=True)
+                        yml.close()                
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_routing_template.render(to_parse_routing=self.learned_routing['vrf'],filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Routing/%s_learned_routing.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type) 
+                            fh.close()
                     
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Routing/%s_learned_routing.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Routing/%s_learned_routing.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Routing/%s_learned_routing_mind_map.html" % (device.alias,device.alias))
@@ -361,10 +392,12 @@ class Collect_Information(aetest.Testcase):
                     parsed_output_netjson_html = learned_routing_netjson_html_template.render(device_alias = device.alias)
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Routing/%s_learned_routing_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)               
+                        fh.write(parsed_output_netjson_json)
+                        fh.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Routing/%s_learned_routing_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
+                        fh.close()
 
                     # ----------------
                     # Store Routing in Device Table in Database
@@ -381,15 +414,18 @@ class Collect_Information(aetest.Testcase):
                     sh_access_lists_template = env.get_template('show_access_lists.j2')                  
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Access_Lists/%s_show_access_lists.json" % device.alias, "w") as fid:
                       json.dump(self.parsed_show_access_lists, fid, indent=4, sort_keys=True)
+                      fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Access_Lists/%s_show_access_lists.yaml" % device.alias, "w") as yml:
                       yaml.dump(self.parsed_show_access_lists, yml, allow_unicode=True)
+                      yml.close()
 
                     for filetype in filetype_loop:
                         parsed_output_type = sh_access_lists_template.render(to_parse_access_list=self.parsed_show_access_lists,filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Access_Lists/%s_show_access_lists.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type) 
+                            fh.close()
                     
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Access_Lists/%s_show_access_lists.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Access_Lists/%s_show_access_lists.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Access_Lists/%s_show_access_lists_mind_map.html" % (device.alias,device.alias))
@@ -407,9 +443,11 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Etherchannel_Summary/%s_show_etherchannel_summary.json" % device.alias, "w") as fid:
                       json.dump(self.parsed_show_etherchannel_summary, fid, indent=4, sort_keys=True)
+                      fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Etherchannel_Summary/%s_show_etherchannel_summary.yaml" % device.alias, "w") as yml:
                       yaml.dump(self.parsed_show_etherchannel_summary, yml, allow_unicode=True)
+                      yml.close()
 
                     for filetype in filetype_loop: 
                         # parsed_output_type is None just in case the "if parsed_output_type in locals()" loop below fails. 
@@ -424,9 +462,11 @@ class Collect_Information(aetest.Testcase):
                         if parsed_output_type in locals():                                                    
                             with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Etherchannel_Summary/%s_show_etherchannel_summary.%s" % (device.alias,filetype), "w") as fh:
                                 fh.write(parsed_output_type)
+                                fh.close()
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Etherchannel_Summary/%s_show_etherchannel_summary_totals.%s" % (device.alias,filetype), "w") as fh:
                           fh.write(parsed_totals)
+                          fh.close()
 
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Etherchannel_Summary/%s_show_etherchannel_summary.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Etherchannel_Summary/%s_show_etherchannel_summary.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Etherchannel_Summary/%s_show_etherchannel_summary_mind_map.html" % (device.alias,device.alias))
@@ -447,15 +487,18 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Inventory/%s_show_inventory.json" % device.alias, "w") as fid:
                       json.dump(self.parsed_show_inventory, fid, indent=4, sort_keys=True)
+                      fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Inventory/%s_show_inventory.yaml" % device.alias, "w") as yml:
                       yaml.dump(self.parsed_show_inventory, yml, allow_unicode=True)
+                      yml.close()
 
                     for filetype in filetype_loop:
                         parsed_output_type = sh_inventory_csr100v_template.render(to_parse_inventory_slot=self.parsed_show_inventory['slot'],to_parse_inventory_main=self.parsed_show_inventory['main'],filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Inventory/%s_show_inventory.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type)
+                            fh.close()
 
                         if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Inventory/%s_show_inventory.md" % device.alias):
                             os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Inventory/%s_show_inventory.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Inventory/%s_show_inventory_mind_map.html" % (device.alias,device.alias))
@@ -472,15 +515,18 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_ARP/%s_show_ip_arp.json" % device.alias, "w") as fid:
                       json.dump(self.parsed_show_ip_arp, fid, indent=4, sort_keys=True)
+                      fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_ARP/%s_show_ip_arp.yaml" % device.alias, "w") as yml:
                       yaml.dump(self.parsed_show_ip_arp, yml, allow_unicode=True)
+                      yml.close()
 
                     for filetype in filetype_loop:  
                         parsed_output_type = sh_ip_arp_template.render(to_parse_ip_arp=self.parsed_show_ip_arp['interfaces'],filetype_loop_jinja2=filetype)
                       
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_ARP/%s_show_ip_arp.%s" % (device.alias,filetype), "w") as fh:
                           fh.write(parsed_output_type)
+                          fh.close()
 
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_ARP/%s_show_ip_arp.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_ARP/%s_show_ip_arp.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_ARP/%s_show_ip_arp_mind_map.html" % (device.alias,device.alias))
@@ -497,15 +543,18 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Interface_Brief/%s_show_ip_int_brief.json" % device.alias, "w") as fid:
                         json.dump(self.parsed_show_ip_int_brief, fid, indent=4, sort_keys=True)
+                        fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Interface_Brief/%s_show_ip_int_brief.yaml" % device.alias, "w") as yml:
                         yaml.dump(self.parsed_show_ip_int_brief, yml, allow_unicode=True)                 
-        
+                        yml.close()
+
                     for filetype in filetype_loop:
                         parsed_output_type = sh_ip_int_brief_template.render(to_parse_interfaces=self.parsed_show_ip_int_brief['interface'],filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Interface_Brief/%s_show_ip_int_brief.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type)
+                            fh.close()
 
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Interface_Brief/%s_show_ip_int_brief.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Interface_Brief/%s_show_ip_int_brief.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Interface_Brief/%s_show_ip_int_brief_mind_map.html" % (device.alias,device.alias))
@@ -522,15 +571,18 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Route/%s_show_ip_route.json" % device.alias, "w") as fid:
                       json.dump(self.parsed_show_ip_route, fid, indent=4, sort_keys=True)
+                      fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Route/%s_show_ip_route.yaml" % device.alias, "w") as yml:
                       yaml.dump(self.parsed_show_ip_route, yml, allow_unicode=True)
+                      yml.close()
 
                     for filetype in filetype_loop:
                         parsed_output_type = sh_ip_route_template.render(to_parse_ip_route=self.parsed_show_ip_route['vrf'],filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Route/%s_show_ip_route.%s" % (device.alias,filetype), "w") as fh:
                           fh.write(parsed_output_type)
+                          fh.close()
                                         
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Route/%s_show_ip_route.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Route/%s_show_ip_route.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Route/%s_show_ip_route_mind_map.html" % (device.alias,device.alias))
@@ -547,15 +599,18 @@ class Collect_Information(aetest.Testcase):
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Version/%s_show_version.json" % device.alias, "w") as fid:
                       json.dump(self.parsed_show_version, fid, indent=4, sort_keys=True)
+                      fid.close()
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Version/%s_show_version.yaml" % device.alias, "w") as yml:
                       yaml.dump(self.parsed_show_version, yml, allow_unicode=True)
+                      yml.close()
 
                     for filetype in filetype_loop:
                         parsed_output_type = sh_ver_template.render(to_parse_version=self.parsed_show_version['version'],filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Version/%s_show_version.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type)
+                            fh.close()
 
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Version/%s_show_version.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Version/%s_show_version.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Version/%s_show_version_mind_map.html" % (device.alias,device.alias))
@@ -572,6 +627,7 @@ class Collect_Information(aetest.Testcase):
 
         with open('Cave_of_Wonders/Cisco/DevNet_Sandbox/Jafar/CSR1000v_Jafar_DB.json') as f:
             data = json.load(f)
+            f.close()
  
         print("JSON file with 2 tables\n")
         print(json.dumps(data, indent = 4, sort_keys=True))        

--- a/DevNet_Sandbox_CSR_magic_carpet.py
+++ b/DevNet_Sandbox_CSR_magic_carpet.py
@@ -24,6 +24,7 @@ from pyats.log.utils import banner
 from jinja2 import Environment, FileSystemLoader
 from ascii_art import GREETING, LEARN, RUNNING, WRITING, FINISHED
 from general_functionalities import ParseShowCommandFunction, ParseLearnFunction
+from genie.libs.conf.device.iosxe.device import Device
 from tinydb import TinyDB, Query
 
 # ----------------
@@ -144,10 +145,10 @@ class Collect_Information(aetest.Testcase):
                     learned_acl_template = env.get_template('learned_acl.j2')
                     learned_acl_netjson_json_template = env.get_template('learned_acl_netjson_json.j2')
                     learned_acl_netjson_html_template = env.get_template('learned_acl_netjson_html.j2')
+                    directory_names = "Learned_ACL"
+                    file_names = "learned_acl" 
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/%s_learned_acl.json" % device.alias, "w") as fid:
-                        json.dump(self.learned_acl, fid, indent=4, sort_keys=True)
-                        fid.close()
+                    self.save_to_json_file(device, directory_names, file_names, self.learned_acl)
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/%s_learned_acl.yaml" % device.alias, "w") as yml:
                         yaml.dump(self.learned_acl, yml, allow_unicode=True)
@@ -189,27 +190,23 @@ class Collect_Information(aetest.Testcase):
                     learned_arp_statistics_netjson_json_template = env.get_template('learned_arp_statistics_netjson_json.j2')
                     learned_arp_statistics_netjson_html_template = env.get_template('learned_arp_statistics_netjson_html.j2')
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.json" % device.alias, "w") as fid:
-                        json.dump(self.learned_arp, fid, indent=4, sort_keys=True)
-                        fid.close()
+                    directory = "Learned_ARP"
+                    filename = "learned_arp"
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.yaml" % device.alias, "w") as yml:
-                        yaml.dump(self.learned_arp, yml, allow_unicode=True)   
-                        yml.close()
+                    self.save_to_json_file(device, directory, filename, self.learned_arp)
+                    self.save_to_yaml_file(device, directory, filename, self.learned_arp)
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_arp_template.render(to_parse_arp=self.learned_arp['interfaces'],filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type) 
-                            fh.close()
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_arp_statistics_template.render(to_parse_arp=self.learned_arp['statistics'],filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_statistics.%s" % (device.alias,filetype), "w") as fh:
                             fh.write(parsed_output_type) 
-                            fh.close()
 
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_mind_map.html" % (device.alias,device.alias))
@@ -217,27 +214,24 @@ class Collect_Information(aetest.Testcase):
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_statistics.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_statistics_mind_map.html" % (device.alias,device.alias))
 
+                    # interface netjson
                     parsed_output_netjson_json = learned_arp_netjson_json_template.render(to_parse_arp=self.learned_arp['interfaces'],device_alias = device.alias)
                     parsed_output_netjson_html = learned_arp_netjson_html_template.render(device_alias = device.alias)
-
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)      
-                        fh.close()         
+                        fh.write(parsed_output_netjson_json)               
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
-                        fh.close()
 
+                    # interface statistics netjson
                     parsed_output_netjson_json = learned_arp_statistics_netjson_json_template.render(to_parse_arp=self.learned_arp['statistics'],device_alias = device.alias)
                     parsed_output_netjson_html = learned_arp_statistics_netjson_html_template.render(device_alias = device.alias)
-
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_statistics_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)     
-                        fh.close()          
+                        fh.write(parsed_output_netjson_json)               
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ARP/%s_learned_arp_statistics_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
-                        fh.close()
+
 
                     # ----------------
                     # Store ARP in Device Table in Database
@@ -253,14 +247,11 @@ class Collect_Information(aetest.Testcase):
                     learned_dot1x_sessions_template = env.get_template('learned_dot1x_sessions.j2')
                     learned_dot1x_sessions_netjson_json_template = env.get_template('learned_dot1x_sessions_netjson_json.j2')
                     learned_dot1x_sessions_netjson_html_template = env.get_template('learned_dot1x_sessions_netjson_html.j2')
-
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x.json" % device.alias, "w") as fid:
-                        json.dump(self.learned_dot1x, fid, indent=4, sort_keys=True)
-                        fh.close()
-
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Dot1X/%s_learned_dot1x.yaml" % device.alias, "w") as yml:
-                        yaml.dump(self.learned_dot1x, yml, allow_unicode=True)   
-                        yml.close()             
+                    directory = "Learned_Dot1X"
+                    filename = "learned_dot1x"
+                    
+                    self.save_to_json_file(device, directory, filename, self.learned_dot1x)
+                    self.save_to_yaml_file(device, directory, filename, self.learned_dot1x)
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_dot1x_template.render(to_parse_dot1x=self.learned_dot1x,filetype_loop_jinja2=filetype)
@@ -317,51 +308,41 @@ class Collect_Information(aetest.Testcase):
                     learned_interface_netjson_html_template = env.get_template('learned_interface_netjson_html.j2')
                     learned_interface_enable_netjson_json_template = env.get_template('learned_interface_enabled_netjson_json.j2')
                     learned_interface_enable_netjson_html_template = env.get_template('learned_interface_enabled_netjson_html.j2')
+                    learned_interface_directory = "Learned_Interface"
+                    learned_interface_file_name = "learned_interface"
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.json" % device.alias, "w") as fid:
-                        json.dump(self.learned_interface, fid, indent=4, sort_keys=True)
-                        fid.close()
-
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.yaml" % device.alias, "w") as yml:
-                        yaml.dump(self.learned_interface, yml, allow_unicode=True)   
-                        yml.close()
+                    self.save_to_json_file(device, learned_interface_directory, learned_interface_file_name, self.learned_interface)
+                    self.save_to_yaml_file(device, learned_interface_directory, learned_interface_file_name, self.learned_interface)
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_interface_template.render(to_parse_interface=self.learned_interface,filetype_loop_jinja2=filetype)
 
                         with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.%s" % (device.alias,filetype), "w") as fh:
-                            fh.write(parsed_output_type) 
-                            fh.close()
-                    
+                            fh.write(parsed_output_type)     
+
                     if os.path.exists("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.md" % device.alias):
                         os.system("markmap --no-open Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.md --output Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface_mind_map.html" % (device.alias,device.alias))
 
+                    # now lets deal with netgraph
                     parsed_output_netjson_json = learned_interface_netjson_json_template.render(to_parse_interface=self.learned_interface,device_alias = device.alias)
                     parsed_output_netjson_html = learned_interface_netjson_html_template.render(device_alias = device.alias)
-
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)   
-                        fh.close()            
+                        fh.write(parsed_output_netjson_json)               
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
-                        fh.close()
 
                     parsed_output_netjson_json = learned_interface_enable_netjson_json_template.render(to_parse_interface=self.learned_interface,device_alias = device.alias)
                     parsed_output_netjson_html = learned_interface_enable_netjson_html_template.render(device_alias = device.alias)
-
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface_enabled_netgraph.json" % device.alias, "w") as fh:
-                        fh.write(parsed_output_netjson_json)
-                        fh.close()               
+                        fh.write(parsed_output_netjson_json)               
 
                     with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface_enabled_netgraph.html" % device.alias, "w") as fh:
                         fh.write(parsed_output_netjson_html)
-                        fh.close()
 
                     # ----------------
                     # Store Interface in Device Table in Database
                     # ----------------
-
                     table.insert(self.learned_interface)
 
                 # Learned Routing
@@ -370,13 +351,11 @@ class Collect_Information(aetest.Testcase):
                     learned_routing_netjson_json_template = env.get_template('learned_routing_netjson_json.j2')
                     learned_routing_netjson_html_template = env.get_template('learned_routing_netjson_html.j2')
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Routing/%s_learned_routing.json" % device.alias, "w") as fid:
-                        json.dump(self.learned_routing, fid, indent=4, sort_keys=True)
-                        fid.close()
+                    directory = "Learned_Routing"
+                    filename = "learned_routing"
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Routing/%s_learned_routing.yaml" % device.alias, "w") as yml:
-                        yaml.dump(self.learned_routing, yml, allow_unicode=True)
-                        yml.close()                
+                    self.save_to_json_file(device, directory, filename, self.learned_routing)
+                    self.save_to_yaml_file(device, directory, filename, self.learned_routing)
 
                     for filetype in filetype_loop:
                         parsed_output_type = learned_routing_template.render(to_parse_routing=self.learned_routing['vrf'],filetype_loop_jinja2=filetype)
@@ -411,14 +390,12 @@ class Collect_Information(aetest.Testcase):
 
                 # Show access-lists
                 if self.parsed_show_access_lists is not None:
-                    sh_access_lists_template = env.get_template('show_access_lists.j2')                  
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Access_Lists/%s_show_access_lists.json" % device.alias, "w") as fid:
-                      json.dump(self.parsed_show_access_lists, fid, indent=4, sort_keys=True)
-                      fid.close()
+                    sh_access_lists_template = env.get_template('show_access_lists.j2')    
+                    show_access_lists_directory = "Show_Access_Lists"
+                    show_access_lists_filename = "show_access_lists"
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Access_Lists/%s_show_access_lists.yaml" % device.alias, "w") as yml:
-                      yaml.dump(self.parsed_show_access_lists, yml, allow_unicode=True)
-                      yml.close()
+                    self.save_to_json_file(device, show_access_lists_directory, show_access_lists_filename, self.parsed_show_access_lists)
+                    self.save_to_yaml_file(device, show_access_lists_directory, show_access_lists_filename, self.parsed_show_access_lists)
 
                     for filetype in filetype_loop:
                         parsed_output_type = sh_access_lists_template.render(to_parse_access_list=self.parsed_show_access_lists,filetype_loop_jinja2=filetype)
@@ -441,13 +418,11 @@ class Collect_Information(aetest.Testcase):
                     sh_etherchannel_summary_template = env.get_template('show_etherchannel_summary.j2')
                     sh_etherchannel_summary_totals_template = env.get_template('show_etherchannel_summary_totals.j2')
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Etherchannel_Summary/%s_show_etherchannel_summary.json" % device.alias, "w") as fid:
-                      json.dump(self.parsed_show_etherchannel_summary, fid, indent=4, sort_keys=True)
-                      fid.close()
+                    sh_etherchannel_summary_directory = "Show_Etherchannel_Summary"
+                    sh_etherchannel_summary_filename = "show_etherchannel_summary"
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Etherchannel_Summary/%s_show_etherchannel_summary.yaml" % device.alias, "w") as yml:
-                      yaml.dump(self.parsed_show_etherchannel_summary, yml, allow_unicode=True)
-                      yml.close()
+                    self.save_to_json_file(device, sh_etherchannel_summary_directory, sh_etherchannel_summary_filename, self.parsed_show_etherchannel_summary)
+                    self.save_to_yaml_file(device, sh_etherchannel_summary_directory, sh_etherchannel_summary_filename, self.parsed_show_etherchannel_summary)
 
                     for filetype in filetype_loop: 
                         # parsed_output_type is None just in case the "if parsed_output_type in locals()" loop below fails. 
@@ -484,14 +459,12 @@ class Collect_Information(aetest.Testcase):
                 if self.parsed_show_inventory is not None:
                     # CSR100v
                     sh_inventory_csr100v_template = env.get_template('show_inventory_CSR100v.j2')
+                    
+                    directory = "Show_Inventory"
+                    filename = "show_inventory" 
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Inventory/%s_show_inventory.json" % device.alias, "w") as fid:
-                      json.dump(self.parsed_show_inventory, fid, indent=4, sort_keys=True)
-                      fid.close()
-
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Inventory/%s_show_inventory.yaml" % device.alias, "w") as yml:
-                      yaml.dump(self.parsed_show_inventory, yml, allow_unicode=True)
-                      yml.close()
+                    self.save_to_json_file(device, directory, filename, self.parsed_show_inventory)
+                    self.save_to_yaml_file(device, directory, filename, self.parsed_show_inventory)
 
                     for filetype in filetype_loop:
                         parsed_output_type = sh_inventory_csr100v_template.render(to_parse_inventory_slot=self.parsed_show_inventory['slot'],to_parse_inventory_main=self.parsed_show_inventory['main'],filetype_loop_jinja2=filetype)
@@ -512,14 +485,11 @@ class Collect_Information(aetest.Testcase):
                 # Show ip arp
                 if self.parsed_show_ip_arp is not None:
                     sh_ip_arp_template = env.get_template('show_ip_arp.j2')
+                    directory = "Show_IP_ARP"
+                    filename = "show_ip_arp"
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_ARP/%s_show_ip_arp.json" % device.alias, "w") as fid:
-                      json.dump(self.parsed_show_ip_arp, fid, indent=4, sort_keys=True)
-                      fid.close()
-
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_ARP/%s_show_ip_arp.yaml" % device.alias, "w") as yml:
-                      yaml.dump(self.parsed_show_ip_arp, yml, allow_unicode=True)
-                      yml.close()
+                    self.save_to_json_file(device, directory, filename, self.parsed_show_ip_arp)
+                    self.save_to_yaml_file(device, directory, filename, self.parsed_show_ip_arp)
 
                     for filetype in filetype_loop:  
                         parsed_output_type = sh_ip_arp_template.render(to_parse_ip_arp=self.parsed_show_ip_arp['interfaces'],filetype_loop_jinja2=filetype)
@@ -540,14 +510,11 @@ class Collect_Information(aetest.Testcase):
                 # Show ip interface brief
                 if self.parsed_show_ip_int_brief is not None:
                     sh_ip_int_brief_template = env.get_template('show_ip_int_brief.j2')
-
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Interface_Brief/%s_show_ip_int_brief.json" % device.alias, "w") as fid:
-                        json.dump(self.parsed_show_ip_int_brief, fid, indent=4, sort_keys=True)
-                        fid.close()
-
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Interface_Brief/%s_show_ip_int_brief.yaml" % device.alias, "w") as yml:
-                        yaml.dump(self.parsed_show_ip_int_brief, yml, allow_unicode=True)                 
-                        yml.close()
+                    directory = "Show_IP_Interface_Brief"
+                    filename = "show_ip_int_brief"
+                    
+                    self.save_to_json_file(device, directory, filename, self.parsed_show_ip_int_brief)
+                    self.save_to_yaml_file(device, directory, filename, self.parsed_show_ip_int_brief)
 
                     for filetype in filetype_loop:
                         parsed_output_type = sh_ip_int_brief_template.render(to_parse_interfaces=self.parsed_show_ip_int_brief['interface'],filetype_loop_jinja2=filetype)
@@ -568,14 +535,11 @@ class Collect_Information(aetest.Testcase):
                 # Show IP Route
                 if self.parsed_show_ip_route is not None:
                     sh_ip_route_template = env.get_template('show_ip_route.j2')
+                    directory = "Show_IP_Route"
+                    filename = "show_ip_route"
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Route/%s_show_ip_route.json" % device.alias, "w") as fid:
-                      json.dump(self.parsed_show_ip_route, fid, indent=4, sort_keys=True)
-                      fid.close()
-
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_IP_Route/%s_show_ip_route.yaml" % device.alias, "w") as yml:
-                      yaml.dump(self.parsed_show_ip_route, yml, allow_unicode=True)
-                      yml.close()
+                    self.save_to_json_file(device, directory, filename, self.parsed_show_ip_route)
+                    self.save_to_yaml_file(device, directory, filename, self.parsed_show_ip_route)
 
                     for filetype in filetype_loop:
                         parsed_output_type = sh_ip_route_template.render(to_parse_ip_route=self.parsed_show_ip_route['vrf'],filetype_loop_jinja2=filetype)
@@ -596,15 +560,12 @@ class Collect_Information(aetest.Testcase):
                 # Show version
                 if self.parsed_show_version is not None:
                     sh_ver_template = env.get_template('show_version.j2')
+                    directory = "Show_Version"
+                    filename = "show_version"
 
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Version/%s_show_version.json" % device.alias, "w") as fid:
-                      json.dump(self.parsed_show_version, fid, indent=4, sort_keys=True)
-                      fid.close()
-
-                    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Show_Version/%s_show_version.yaml" % device.alias, "w") as yml:
-                      yaml.dump(self.parsed_show_version, yml, allow_unicode=True)
-                      yml.close()
-
+                    self.save_to_json_file(device, directory, filename, self.parsed_show_version)
+                    self.save_to_yaml_file(device, directory, filename, self.parsed_show_version)
+                    
                     for filetype in filetype_loop:
                         parsed_output_type = sh_ver_template.render(to_parse_version=self.parsed_show_version['version'],filetype_loop_jinja2=filetype)
 
@@ -630,4 +591,33 @@ class Collect_Information(aetest.Testcase):
             f.close()
  
         print("JSON file with 2 tables\n")
-        print(json.dumps(data, indent = 4, sort_keys=True))        
+        print(json.dumps(data, indent = 4, sort_keys=True))     
+    
+
+    """
+    Meant to dump data to json. For example, in the case of Access Lists, where we would do: 
+    We now call save_to_json_file(device, "Learned_ACL", "learned_acl", self.learned_acl)
+    would create a file inside "Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_ACL/[device.alias].json"
+    """
+    def save_to_json_file(self, device, directory, file_name, content):
+        file_path = "Cave_of_Wonders/Cisco/DevNet_Sandbox/{}/{}_{}.json".format(directory, device.alias, file_name)
+        with open(file_path, "w") as json_file:
+            json.dump(content, json_file, indent=4, sort_keys=True)
+            json_file.close()
+    
+    def save_to_yaml_file(self, device, directory, file_name, content):
+        file_path = "Cave_of_Wonders/Cisco/DevNet_Sandbox/{}/{}_{}.yaml".format(directory, device.alias, file_name)
+        with open(file_path, "w") as yml_file:
+            yaml.dump(content, yml_file, allow_unicode=True)
+            yml_file.close()
+    
+    """
+    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.%s" % (device.alias,filetype), "w") as fh:
+        fh.write(parsed_output_type) 
+        fh.close()
+    """
+    def save_to_specified_file_type(self, device, directory, file_name, content, file_type):
+        file_path = "Cave_of_Wonders/Cisco/DevNet_Sandbox/{}/{}_{}.{}".format(directory, device.alias, file_name, file_type)
+        with open(file_path, "w") as opened_file:
+            opened_file.write(content)
+            opened_file.close()

--- a/DevNet_Sandbox_CSR_magic_carpet.py
+++ b/DevNet_Sandbox_CSR_magic_carpet.py
@@ -611,11 +611,6 @@ class Collect_Information(aetest.Testcase):
             yaml.dump(content, yml_file, allow_unicode=True)
             yml_file.close()
     
-    """
-    with open("Cave_of_Wonders/Cisco/DevNet_Sandbox/Learned_Interface/%s_learned_interface.%s" % (device.alias,filetype), "w") as fh:
-        fh.write(parsed_output_type) 
-        fh.close()
-    """
     def save_to_specified_file_type(self, device, directory, file_name, content, file_type):
         file_path = "Cave_of_Wonders/Cisco/DevNet_Sandbox/{}/{}_{}.{}".format(directory, device.alias, file_name, file_type)
         with open(file_path, "w") as opened_file:


### PR DESCRIPTION
<h3>Close Opened Files</h3>
Most of the files were open and not closed. 

An example:
```python
with open('filex') as fh:
     fh.write(some_data)
```
This will not be a big issue but might cause problems down the road. When we don't close files, all the data for the files are stored in the buffer until they are closed, or the program exits. If the number of files increase, the buffer sizes may cause speed issues.

An appropriate way for closing the files is:
```python
with open('filex') as fh:
     fh.write(some_data)
     fh.close()
```

<h3>Created two functions for repetitive tasks</h3>
The following functions have been created:

```python
  def save_to_json_file(self, device, directory, file_name, content):
        file_path = "Cave_of_Wonders/Cisco/DevNet_Sandbox/{}/{}_{}.json".format(directory, device.alias, file_name)
        with open(file_path, "w") as json_file:
            json.dump(content, json_file, indent=4, sort_keys=True)
            json_file.close()
    
    def save_to_yaml_file(self, device, directory, file_name, content):
        file_path = "Cave_of_Wonders/Cisco/DevNet_Sandbox/{}/{}_{}.yaml".format(directory, device.alias, file_name)
        with open(file_path, "w") as yml_file:
            yaml.dump(content, yml_file, allow_unicode=True)
            yml_file.close()
    
    def save_to_specified_file_type(self, device, directory, file_name, content, file_type):
        file_path = "Cave_of_Wonders/Cisco/DevNet_Sandbox/{}/{}_{}.{}".format(directory, device.alias, file_name, file_type)
        with open(file_path, "w") as opened_file:
            opened_file.write(content)
            opened_file.close()
```

To reduce repetitiveness of items inside the codebase. 

<b>Note: These changes have only been applied to the Devnet_CSR_magic_carpet.py file. They will be implemented in other files once the changes are approved to be okay and usable. </b>